### PR TITLE
Add support for local mode via Ollama

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -3,7 +3,9 @@
 ## Requirements
 
 - JupyterLab >= 4.3.0
-- An IBM Quantum premium account
+- Access to either:
+  - An IBM Quantum premium account
+  - A service exposing LLMs using OpenAI-compatible API endpoints
 
 ## Install
 
@@ -112,7 +114,7 @@ There are a few settings we recommend to edit in your user settings.
 
 3. If you want to change the instance of the Qiskit Code Assistant Service that the
    extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.
-   This can also be set to any OpenAI compatible API endpoint.
+   This can also be set to any service exposing LLMs using OpenAI-compatible API endpoints.
 
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -114,7 +114,6 @@ There are a few settings we recommend to edit in your user settings.
    extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.
    This can also be set to any OpenAI compatible API endpoint.
 
-
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -111,7 +111,9 @@ There are a few settings we recommend to edit in your user settings.
    `Tab`, the inline completer has a default of 10 seconds.
 
 3. If you want to change the instance of the Qiskit Code Assistant Service that the
-   extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`
+   extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.
+   This can also be set to any OpenAI compatible API endpoint.
+
 
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -117,7 +117,8 @@ There are a few settings we recommend to edit in your user settings.
    `Tab`, the inline completer has a default of 10 seconds.
 
 3. If you want to change the instance of the Qiskit Code Assistant Service that the
-   extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`
+   extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.
+   This can also be set to any OpenAI compatible API endpoint.
 
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -1,7 +1,5 @@
 # Qiskit Code Assistant (Beta)
 
-> This experimental feature is only available, as of today, to IBM Quantum premium users.
-> If you are not part of the IBM Quantum premium plan, you can still install this extension; however you will not be able to use the assistant.
 > The Qiskit Code Assistant is a beta release, subject to change.
 
 Write and optimize Qiskit code with a generative AI code assistant.
@@ -118,7 +116,7 @@ There are a few settings we recommend to edit in your user settings.
 
 3. If you want to change the instance of the Qiskit Code Assistant Service that the
    extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.
-   This can also be set to any OpenAI compatible API endpoint.
+   This can also be set to any service exposing LLMs using OpenAI-compatible API endpoints.
 
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ for the frontend extension.
 ## Requirements
 
 - JupyterLab >= 4.2.0
-- An IBM Quantum premium account
+- Access to either:
+  - An IBM Quantum premium account
+  - A model with an OpenAI compatible API endpoint
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for the frontend extension.
 - JupyterLab >= 4.3.0
 - Access to either:
   - An IBM Quantum premium account
-  - A model with an OpenAI compatible API endpoint
+  - A service exposing LLMs using OpenAI-compatible API endpoints
 
 ## Install
 

--- a/qiskit_code_assistant_jupyterlab/handlers.py
+++ b/qiskit_code_assistant_jupyterlab/handlers.py
@@ -25,6 +25,8 @@ from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 from qiskit_ibm_runtime import QiskitRuntimeService
 
+OPENAI_VERSION = "v1"
+
 runtime_configs = {
     "service_url": "http://localhost",
     "api_token": "",
@@ -97,7 +99,7 @@ class ServiceUrlHandler(APIHandler):
         try:
             r = requests.get(url_path_join(runtime_configs["service_url"]), headers=get_header())
             runtime_configs["is_openai"] = (r.json()["name"] != "qiskit-code-assistant")
-        except requests.exceptions.JSONDecodeError:
+        except (requests.exceptions.JSONDecodeError, KeyError):
             runtime_configs["is_openai"] = True
         finally:
             self.finish(json.dumps({"url": runtime_configs["service_url"]}))
@@ -122,7 +124,7 @@ class ModelsHandler(APIHandler):
     @tornado.web.authenticated
     def get(self):
         if runtime_configs["is_openai"]:
-            url = url_path_join(runtime_configs["service_url"], "v1", "models")
+            url = url_path_join(runtime_configs["service_url"], OPENAI_VERSION, "models")
             models = []
             try:
                 r = requests.get(url, headers=get_header())
@@ -153,7 +155,7 @@ class ModelHandler(APIHandler):
     @tornado.web.authenticated
     def get(self, id):
         if runtime_configs["is_openai"]:
-            url = url_path_join(runtime_configs["service_url"], "v1", "models", id)
+            url = url_path_join(runtime_configs["service_url"], OPENAI_VERSION, "models", id)
             model = {}
             try:
                 r = requests.get(url, headers=get_header())
@@ -223,7 +225,7 @@ class PromptHandler(APIHandler):
     @tornado.web.authenticated
     def post(self, id):
         if runtime_configs["is_openai"]:
-            url = url_path_join(runtime_configs["service_url"], "v1", "completions")
+            url = url_path_join(runtime_configs["service_url"], OPENAI_VERSION, "completions")
             result = {}
             try:
                 r = requests.post(url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     postServiceUrl(settings.composite['serviceUrl'] as string);
     settings.changed.connect(() =>
-      postServiceUrl(settings.composite['serviceUrl'] as string)
+      postServiceUrl(settings.composite['serviceUrl'] as string).then(() =>
+        refreshModelsList()
+      )
     );
 
     const provider = new QiskitCompletionProvider({ settings });

--- a/src/service/autocomplete.ts
+++ b/src/service/autocomplete.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getModel, postModelPrompt } from './api';
+import { postModelPrompt } from './api';
 import { showDisclaimer } from './disclaimer';
 import { getCurrentModel } from './modelHandler';
 import { checkAPIToken } from './token';
@@ -51,25 +51,21 @@ export async function autoComplete(text: string): Promise<ICompletionReturn> {
       const requestText = text.slice(startingOffset, text.length);
       const model = getCurrentModel();
 
-      return await getModel(model?._id || '')
-        .then(async model => {
-          if (model.disclaimer?.accepted) {
+      if (model === undefined) {
+        console.error('Failed to send prompt', 'No model selected');
+        return emptyReturn;
+      } else if (model.disclaimer?.accepted) {
+        return await promptPromise(model._id, requestText);
+      } else {
+        return await showDisclaimer(model._id).then(async accepted => {
+          if (accepted) {
             return await promptPromise(model._id, requestText);
           } else {
-            return await showDisclaimer(model._id).then(async accepted => {
-              if (accepted) {
-                return await promptPromise(model._id, requestText);
-              } else {
-                console.error('Disclaimer not accepted');
-                return emptyReturn;
-              }
-            });
+            console.error('Disclaimer not accepted');
+            return emptyReturn;
           }
-        })
-        .catch(reason => {
-          console.error('Failed to send prompt', reason);
-          return emptyReturn;
         });
+      }
     })
     .catch(reason => {
       console.error('Failed to send prompt', reason);


### PR DESCRIPTION
Adds support for running against local models by supporting the OpenAI API in addition to the Qiskit Code Assistant service API.

This allows users to input any OpenAL compatible API URL, such as Ollama, instead of a Qiskit Code Assistant service URL and the server extension will detect which API is set and call the correct endpoints.

Fixes #9