### PR TITLE
Add a setting to disable telemetry

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -118,6 +118,9 @@ There are a few settings we recommend to edit in your user settings.
 
 5. Telemetry can be disabled by unchecking the `enableTelemetry` setting.
 
+    > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
+    What is collected is whether a code suggestion was accepted or dismissed.
+
 ## Troubleshooting
 
 If you are seeing the frontend extension, but it is not working, check that the server

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -118,8 +118,8 @@ There are a few settings we recommend to edit in your user settings.
 
 5. Telemetry can be disabled by unchecking the `enableTelemetry` setting.
 
-    > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
-    What is collected is whether a code suggestion was accepted or dismissed.
+   > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
+   > What is collected is whether a code suggestion was accepted or dismissed.
 
 ## Troubleshooting
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -116,7 +116,7 @@ There are a few settings we recommend to edit in your user settings.
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.
 
-5. Telemetry can be disabled by unselecting the `enableTelemetry` setting.
+5. Telemetry can be disabled by unchecking the `enableTelemetry` setting.
 
 ## Troubleshooting
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -116,6 +116,8 @@ There are a few settings we recommend to edit in your user settings.
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.
 
+5. Telemetry can be disabled by unselecting the `enableTelemetry` setting.
+
 ## Troubleshooting
 
 If you are seeing the frontend extension, but it is not working, check that the server

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -124,8 +124,8 @@ There are a few settings we recommend to edit in your user settings.
 
 5. Telemetry can be disabled by unchecking the `enableTelemetry` setting.
 
-    > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
-    What is collected is whether a code suggestion was accepted or dismissed.
+   > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
+   > What is collected is whether a code suggestion was accepted or dismissed.
 
 ## Terms of use
 

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -124,6 +124,9 @@ There are a few settings we recommend to edit in your user settings.
 
 5. Telemetry can be disabled by unchecking the `enableTelemetry` setting.
 
+    > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
+    What is collected is whether a code suggestion was accepted or dismissed.
+
 ## Terms of use
 
 - [End User License Agreement (EULA)](https://github.com/Qiskit/qiskit-code-assistant-jupyterlab/blob/main/docs/EULA.md) acceptance required before starting to use the model acceptance required before starting to use the model

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -122,6 +122,8 @@ There are a few settings we recommend to edit in your user settings.
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.
 
+5. Telemetry can be disabled by unselecting the `enableTelemetry` setting.
+
 ## Terms of use
 
 - [End User License Agreement (EULA)](https://github.com/Qiskit/qiskit-code-assistant-jupyterlab/blob/main/docs/EULA.md) acceptance required before starting to use the model acceptance required before starting to use the model

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -122,7 +122,7 @@ There are a few settings we recommend to edit in your user settings.
 4. Keyboard shortcuts can be changed by searching for `completer` in the Keyboard Shortcuts
    settings and adding new shortcuts for the relevant commands.
 
-5. Telemetry can be disabled by unselecting the `enableTelemetry` setting.
+5. Telemetry can be disabled by unchecking the `enableTelemetry` setting.
 
 ## Terms of use
 

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -26,6 +26,12 @@
       "description": "Whether to fetch completions for QiskitCodeAssistant:completer",
       "type": "boolean",
       "default": true
+    },
+    "enableTelemetry": {
+      "title": "Enable Telemetry",
+      "description": "Send telemetry to the The Qiskit Code Assistant Service",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -29,7 +29,7 @@
     },
     "enableTelemetry": {
       "title": "Enable Telemetry",
-      "description": "Send telemetry to the The Qiskit Code Assistant Service",
+      "description": "Send telemetry to the Qiskit Code Assistant Service",
       "type": "boolean",
       "default": true
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,12 +96,17 @@ const plugin: JupyterFrontEndPlugin<void> = {
       category: 'Qiskit Code Assistant'
     });
 
-    completionProviderManager.selected.connect((completer, selection) =>
-      provider.accept(selection.insertText)
-    );
+    completionProviderManager.selected.connect((completer, selection) => {
+      if (settings.composite['enableTelemetry'] as boolean) {
+        provider.accept(selection.insertText)
+      }
+    });
 
     app.commands.commandExecuted.connect((registry, executed) => {
-      if (executed.id === CommandIDs.acceptInline) {
+      if (
+        executed.id === CommandIDs.acceptInline &&
+        settings.composite['enableTelemetry'] as boolean
+      ) {
         inlineProvider.accept();
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,14 +98,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     completionProviderManager.selected.connect((completer, selection) => {
       if (settings.composite['enableTelemetry'] as boolean) {
-        provider.accept(selection.insertText)
+        provider.accept(selection.insertText);
       }
     });
 
     app.commands.commandExecuted.connect((registry, executed) => {
       if (
         executed.id === CommandIDs.acceptInline &&
-        settings.composite['enableTelemetry'] as boolean
+        (settings.composite['enableTelemetry'] as boolean)
       ) {
         inlineProvider.accept();
       }


### PR DESCRIPTION
# Description

This adds a new `enableTelemetry` boolean JupyterLab setting that is checked before sending a POST call to `prompt/<id>/acceptance`.
The default value is `true`.

## Linked Issue(s)

Fixes #10

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual testing by switching the setting on and off and checking the inspector network tab to see if the `acceptance` endpoint is called after accepting a prompt in various ways.

![Screenshot 2024-10-30 at 1 30 49 PM](https://github.com/user-attachments/assets/1d5c1180-7553-4d57-898b-d119b593da76)
