### PR TITLE
Increasing timeouts for generation to 15 seconds

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -83,7 +83,7 @@ widget to cycle or accept
 
 ![inline complete example](docs/images/inline-complete.png)
 
-> NOTE: The service can sometime take a few seconds to retrun a suggestion, you can see
+> NOTE: The service can sometime take a few seconds to return a suggestion, you can see
 > when the service is working by checking the status bar
 
 ![working](docs/images/statusbar-working.png)
@@ -107,10 +107,11 @@ There are a few settings we recommend to edit in your user settings.
 1. Inline Completer `showWidget` can be set to `always` in order to always show the
    inline completer widget to cycle through and select a completion item
 
-2. Code Completion `providerTimeout` can be increased, our suggested value is `10000` or
-   10 seconds. This is 1 second by default and the Qiskit Code Assistant API rarely returns
+2. Code Completion `providerTimeout` can be increased, our suggested value is `15000` or
+   15 seconds. This is 1 second by default and the Qiskit Code Assistant API rarely returns
    within 1 second. This setting only apply the the standard completer that is invoked with
-   `Tab`, the inline completer has a default of 10 seconds.
+   `Tab`, the inline completer has a default of 15 seconds and can be also configured via the
+   `inlineProviderTimeout` setting.
 
 3. If you want to change the instance of the Qiskit Code Assistant Service that the
    extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -109,10 +109,11 @@ There are a few settings we recommend to edit in your user settings.
 1. Inline Completer `showWidget` can be set to `always` in order to always show the
    inline completer widget to cycle through and select a completion item
 
-2. Code Completion `providerTimeout` can be increased, our suggested value is `10000` or
-   10 seconds. This is 1 second by default and the Qiskit Code Assistant API rarely returns
+2. Code Completion `providerTimeout` can be increased, our suggested value is `15000` or
+   15 seconds. This is 1 second by default and the Qiskit Code Assistant API rarely returns
    within 1 second. This setting only apply the the standard completer that is invoked with
-   `Tab`, the inline completer has a default of 10 seconds.
+   `Tab`, the inline completer has a default of 15 seconds and can be also configured via the
+   `inlineProviderTimeout` setting.
 
 3. If you want to change the instance of the Qiskit Code Assistant Service that the
    extension should use you can edit the Qiskit Code Assistant setting `serviceUrl`.

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -41,6 +41,22 @@
       "description": "Send telemetry to the Qiskit Code Assistant Service",
       "type": "boolean",
       "default": true
+    },
+    "providerTimeout": {
+      "title": "Provider Timeout (milliseconds)",
+      "description": "Timeout for completion provider requests in milliseconds. Recommended value is 15000 (15 seconds) for Qiskit Code Assistant API.",
+      "type": "number",
+      "default": 15000,
+      "minimum": 1000,
+      "maximum": 30000
+    },
+    "inlineProviderTimeout": {
+      "title": "Inline Provider Timeout (milliseconds)",
+      "description": "Timeout for inline completion provider requests in milliseconds.",
+      "type": "number",
+      "default": 15000,
+      "minimum": 1000,
+      "maximum": 30000
     }
   },
   "additionalProperties": false

--- a/src/QiskitCompletionProvider.ts
+++ b/src/QiskitCompletionProvider.ts
@@ -82,6 +82,10 @@ export class QiskitCompletionProvider implements ICompletionProvider {
     this.app = options.app;
   }
 
+  get timeout(): number {
+    return (this.settings.composite['providerTimeout'] as number) || 15000;
+  }
+
   async fetch(
     request: CompletionHandler.IRequest,
     context: ICompletionContext
@@ -131,16 +135,25 @@ export class QiskitInlineCompletionProvider
   readonly name: string = 'Qiskit Code Assistant';
 
   app: JupyterFrontEnd;
+  settings: ISettingRegistry.ISettings;
   prompt_id: string = '';
-  schema: ISettingRegistry.IProperty = {
-    default: {
-      enabled: true,
-      timeout: 10000
-    }
-  };
 
-  constructor(options: { app: JupyterFrontEnd }) {
+  constructor(options: {
+    app: JupyterFrontEnd;
+    settings: ISettingRegistry.ISettings;
+  }) {
     this.app = options.app;
+    this.settings = options.settings;
+  }
+
+  get schema(): ISettingRegistry.IProperty {
+    return {
+      default: {
+        enabled: true,
+        timeout:
+          (this.settings.composite['inlineProviderTimeout'] as number) || 15000
+      }
+    };
   }
 
   async fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
     );
 
     const provider = new QiskitCompletionProvider({ settings, app });
-    const inlineProvider = new QiskitInlineCompletionProvider({ app });
+    const inlineProvider = new QiskitInlineCompletionProvider({
+      app,
+      settings
+    });
     completionProviderManager.registerProvider(provider);
     completionProviderManager.registerInlineProvider(inlineProvider);
 


### PR DESCRIPTION
# Description

Increasing the `providerTimeout` and `inlineProviderTimeout` to 15 seconds by default

## Linked Issue(s)

Fixes #22 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Manually

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
