### PR TITLE
add support for streaming endpoints

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -124,6 +124,8 @@ There are a few settings we recommend to edit in your user settings.
    > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
    > What is collected is whether a code suggestion was accepted or dismissed.
 
+6. Response streaming can be enabled by checking the `enableStreaming` setting.
+
 ## Troubleshooting
 
 If you are seeing the frontend extension, but it is not working, check that the server

--- a/README-PyPi.md
+++ b/README-PyPi.md
@@ -126,6 +126,8 @@ There are a few settings we recommend to edit in your user settings.
    > **NOTE**: The telemetry does not collect your code nor the suggested code completions.
    > What is collected is whether a code suggestion was accepted or dismissed.
 
+6. Response streaming can be enabled by checking the `enableStreaming` setting.
+
 ## Terms of use
 
 - [End User License Agreement (EULA)](https://github.com/Qiskit/qiskit-code-assistant-jupyterlab/blob/main/docs/EULA.md) acceptance required before starting to use the model acceptance required before starting to use the model

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -41,6 +41,12 @@
       "description": "Send telemetry to the Qiskit Code Assistant Service",
       "type": "boolean",
       "default": true
+    },
+    "enableStreaming": {
+      "title": "Enable Streaming",
+      "description": "Stream response from the Qiskit Code Assistant Service",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false

--- a/src/QiskitCompletionProvider.ts
+++ b/src/QiskitCompletionProvider.ts
@@ -31,7 +31,7 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import { Widget } from '@lumino/widgets';
 
 import { postModelPromptAccept } from './service/api';
-import { autoComplete } from './service/autocomplete';
+import { autoComplete, autoCompleteStreaming } from './service/autocomplete';
 import { qiskitIcon } from './utils/icons';
 import { ICompletionReturn } from './utils/schema';
 
@@ -130,6 +130,7 @@ export class QiskitInlineCompletionProvider
   readonly identifier: string = 'qiskit-code-assistant-inline-completer';
   readonly name: string = 'Qiskit Code Assistant';
 
+  settings: ISettingRegistry.ISettings;
   app: JupyterFrontEnd;
   prompt_id: string = '';
   schema: ISettingRegistry.IProperty = {
@@ -139,7 +140,13 @@ export class QiskitInlineCompletionProvider
     }
   };
 
-  constructor(options: { app: JupyterFrontEnd }) {
+  _streamPromises: Map<string, AsyncGenerator> = new Map();
+
+  constructor(options: {
+    settings: ISettingRegistry.ISettings;
+    app: JupyterFrontEnd;
+  }) {
+    this.settings = options.settings;
     this.app = options.app;
   }
 
@@ -152,9 +159,22 @@ export class QiskitInlineCompletionProvider
       return { items: [] };
     }
 
+    const streamingEnabled = this.settings.composite['enableStreaming'] as boolean;
     const text = getInputText(request.text, context.widget);
 
-    return autoComplete(text).then(results => {
+    if (streamingEnabled) {
+      const results = await autoCompleteStreaming(text)
+
+      const streamToken = `qiskit-code-assitant_${(new Date()).toISOString()}`
+      this._streamPromises.set(streamToken, results);
+
+      return { items: [{
+        insertText: '',
+        isIncomplete: true, // trigger the call to `stream()` for data
+        token: streamToken
+      }]};
+    } else {
+      const results = await autoComplete(text)
       this.prompt_id = results.prompt_id;
       if (this.prompt_id) {
         lastPrompt = results;
@@ -166,7 +186,35 @@ export class QiskitInlineCompletionProvider
           return { insertText: item };
         })
       };
-    });
+    }
+  }
+
+
+  /**
+   * handle streaming prompt response
+   * @param token 
+   */
+  async *stream(token: string) {
+    const results = this._streamPromises.get(token);
+    if (!results) return;
+
+    let text = ''
+    let lastChunk: ICompletionReturn | undefined = undefined;
+    for await (let chunk of results) {
+      lastChunk = chunk as ICompletionReturn;
+      text += lastChunk.items[0]
+      yield { response: { insertText: text } }
+    }
+
+    this._streamPromises.delete(token)
+
+    if (lastChunk) {
+      this.prompt_id = lastChunk.prompt_id;
+      if (this.prompt_id) {
+        lastPrompt = lastChunk;
+        this.app.commands.notifyCommandChanged(FEEDBACK_COMMAND);
+      }
+    }
   }
 
   async isApplicable(context: ICompletionContext): Promise<boolean> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     );
 
     const provider = new QiskitCompletionProvider({ settings, app });
-    const inlineProvider = new QiskitInlineCompletionProvider({ app });
+    const inlineProvider = new QiskitInlineCompletionProvider({ settings, app });
     completionProviderManager.registerProvider(provider);
     completionProviderManager.registerInlineProvider(inlineProvider);
 


### PR DESCRIPTION
# Description

this PR adds supports for using streaming endpoints for the inline code completion. a new settings has been added to allow users to enable/disable streaming.

streaming support is added specifically for the inline code completion (and not the code completer)

## Linked Issue(s)

Fixes #25 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- tested code completion connecting to local service deployment with streaming setting enabled
- tested code completion connecting to local service deployment with streaming setting disabled
- tested code completion connecting to hosted service deployment with streaming setting enabled
- tested code completion connecting to hosted service deployment with streaming setting disabled


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
